### PR TITLE
Fix is_prime calculation

### DIFF
--- a/contracts/eosmechanics.cpp
+++ b/contracts/eosmechanics.cpp
@@ -86,7 +86,10 @@ CONTRACT eosmechanics : public eosio::contract {
             const int to = sqrt(p);
             int i;
             for (i = 3; i <= to; i += 2) {  
-                if (!((prime = BOOL(p)) % i)) break;
+		if (p % i == 0) {
+		    prime = FALSE;
+		    break;
+		}
             }
             return prime;
         }


### PR DESCRIPTION
Not that it really matters, but the `is_prime` calculation always returns `true`. This PR fixes the logic.